### PR TITLE
Fix typo in `slapd` service name

### DIFF
--- a/controls/ubuntu-18.04-server-cis-2.2.6.rb
+++ b/controls/ubuntu-18.04-server-cis-2.2.6.rb
@@ -40,7 +40,7 @@ surface."
   tag cis_rid: "2.2.6"
 
   if package('slapd').installed?
-    describe service('isc-dhcp-server') do
+    describe service('slapd') do
       it { should_not be_enabled }
       it { should_not be_running }
     end


### PR DESCRIPTION
It looks like a simple copy/paste error that I noticed.