### PR TITLE
refactored 4.1 checks to better use the auditd resource

### DIFF
--- a/controls/ubuntu-18.04-server-cis-4.1.10.rb
+++ b/controls/ubuntu-18.04-server-cis-4.1.10.rb
@@ -130,14 +130,39 @@ ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
   tag cis_cdc_version: "7"
   tag cis_rid: "4.1.10"
 
-  describe auditd do
-    its('lines') { should include "-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=#{login_defs.UID_MIN} -F auid!=4294967295 -k access" }
-    its('lines') { should include "-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=#{login_defs.UID_MIN} -F auid!=4294967295 -k access" }
-  end
+  arches = ['b32']
   if os.arch.match?(/64/)
-    describe auditd do
-      its('lines') { should include "-a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=#{login_defs.UID_MIN} -F auid!=4294967295 -k access" }
-      its('lines') { should include "-a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=#{login_defs.UID_MIN} -F auid!=4294967295 -k access" }
+    arches.push('b64')
+  end
+
+  syscalls = [
+    'creat',
+    'open',
+    'openat',
+    'truncate',
+    'ftruncate'
+  ]
+
+  syscalls.each do |syscall|
+    arches.each do |a|
+      describe auditd.syscall(syscall).where { arch == a && key == 'access'  } do
+        its('action.uniq') { should eq ['always'] }
+        its('list.uniq') { should eq ['exit'] }
+        its('fields.flatten.uniq') {  should include "auid>=#{login_defs.UID_MIN}" }
+        its('exit') { should include '-EACCES' }
+        its('exit') { should include '-EPERM' }
+      end
+
+      # the rule states that `auid!=4294967295` but this comes back as `auid!=-1` when queries via `auditctl -l`
+      # this check will allow either.
+      describe.one do
+        describe auditd.syscall(syscall).where { arch == a && key == 'access'  } do
+          its('fields.flatten.uniq') {  should include "auid!=-1" }
+        end
+        describe auditd.syscall(syscall).where { arch == a && key == 'access'  } do
+          its('fields.flatten.uniq') {  should include "auid!=4294967295" }
+        end
+      end
     end
   end
 end

--- a/controls/ubuntu-18.04-server-cis-4.1.14.rb
+++ b/controls/ubuntu-18.04-server-cis-4.1.14.rb
@@ -46,8 +46,15 @@ unauthorized change has been made to scope of system administrator activity."
   tag cis_controls: ["4.8"]
   tag cis_cdc_version: "7"
   tag cis_rid: "4.1.14"
-  describe auditd do
-    its('lines') { should include "-w /etc/sudoers -p wa -k scope" }
-    its('lines') { should include "-w /etc/sudoers.d/ -p wa -k scope" }
+
+  files = [
+    '/etc/sudoers',
+    '/etc/sudoers.d'
+  ]
+
+  files.each do |file|
+    describe auditd.file(file).where { key == "scope" } do
+      its('permissions') { should include ['w', 'a'] }
+    end
   end
 end

--- a/controls/ubuntu-18.04-server-cis-4.1.15.rb
+++ b/controls/ubuntu-18.04-server-cis-4.1.15.rb
@@ -69,7 +69,7 @@ the output includes a file path
     subject{ sudo_log_file }
     it { should_not be_empty }
   end
-  describe auditd do
-    its('lines') { should include "-w #{sudo_log_file.chomp} -p wa -k actions" }
+  describe auditd.file(sudo_log_file.chomp).where { key == "actions" } do
+    its('permissions') { should include ['w', 'a'] }
   end
 end

--- a/controls/ubuntu-18.04-server-cis-4.1.4.rb
+++ b/controls/ubuntu-18.04-server-cis-4.1.4.rb
@@ -65,11 +65,18 @@ attempting to hide their activities or compromise additional accounts."
   tag cis_controls: ["4.8"]
   tag cis_cdc_version: "7"
   tag cis_rid: "4.1.4"
-  describe auditd do
-    its('lines') { should include "-w /etc/group -p wa -k identity" }
-    its('lines') { should include "-w /etc/passwd -p wa -k identity" }
-    its('lines') { should include "-w /etc/gshadow -p wa -k identity" }
-    its('lines') { should include "-w /etc/shadow -p wa -k identity" }
-    its('lines') { should include "-w /etc/security/opasswd -p wa -k identity" }
+
+  files = [
+    '/etc/group',
+    '/etc/passwd',
+    '/etc/gshadow',
+    '/etc/shadow',
+    '/etc/security/opasswd'
+  ]
+
+  files.each do |file|
+    describe auditd.file(file).where { key == "identity" } do
+      its('permissions') { should include ['w', 'a'] }
+    end
   end
 end

--- a/controls/ubuntu-18.04-server-cis-4.1.6.rb
+++ b/controls/ubuntu-18.04-server-cis-4.1.6.rb
@@ -56,8 +56,15 @@ security contexts, leading to a compromise of the system."
   tag cis_cdc_version: "7"
   tag cis_rid: "4.1.6"
 
-  describe auditd do
-    its('lines') { should include "-w /etc/apparmor/ -p wa -k MAC-policy" }
-    its('lines') { should include "-w /etc/apparmor.d/ -p wa -k MAC-policy" }
+
+  files = [
+    '/etc/apparmor/',
+    '/etc/apparmor.d/'
+  ]
+
+  files.each do |file|
+    describe auditd.file(file).where { key == "MAC-policy" } do
+      its('permissions') { should include ['w', 'a'] }
+    end
   end
 end

--- a/controls/ubuntu-18.04-server-cis-4.1.7.rb
+++ b/controls/ubuntu-18.04-server-cis-4.1.7.rb
@@ -59,9 +59,16 @@ logins."
   tag cis_cdc_version: "7"
   tag cis_rid: "4.1.7"
 
-  describe auditd do
-    its('lines') { should include "-w /var/log/faillog -p wa -k logins" }
-    its('lines') { should include "-w /var/log/lastlog -p wa -k logins" }
-    its('lines') { should include "-w /var/log/tallylog -p wa -k logins" }
+
+  files = [
+    '/var/log/faillog',
+    '/var/log/lastlog',
+    '/var/log/tallylog'
+  ]
+
+  files.each do |file|
+    describe auditd.file(file).where { key == "logins" } do
+      its('permissions') { should include ['w', 'a'] }
+    end
   end
 end

--- a/controls/ubuntu-18.04-server-cis-4.1.8.rb
+++ b/controls/ubuntu-18.04-server-cis-4.1.8.rb
@@ -63,9 +63,19 @@ log in)."
   tag cis_cdc_version: "7"
   tag cis_rid: "4.1.8"
 
-  describe auditd do
-    its('lines') { should include "-w /var/run/utmp -p wa -k session" }
-    its('lines') { should include "-w /var/log/wtmp -p wa -k logins" }
-    its('lines') { should include "-w /var/log/btmp -p wa -k logins" }
+  files = [
+    '/var/log/wtmp',
+    '/var/log/btmp'
+  ]
+
+  files.each do |file|
+    describe auditd.file(file).where { key == "logins" } do
+      its('permissions') { should include ['w', 'a'] }
+    end
+  end
+
+
+  describe auditd.file('/var/run/utmp').where { key == "session" } do
+    its('permissions') { should include ['w', 'a'] }
   end
 end


### PR DESCRIPTION
I realized there were some bugs in the checks I created the other day, when checking for rules that monitor multiple syscalls. The check was looking for strings like `-S syscall1 -S syscall2` (which is the format when inspecting the rules files on disk) but they were failing because the `auditd.lines` resource (and `auditctl -l`) return this in the form `-S syscall1,syscall2`.

I also realized that I could make better use of the `auditd` resource and its fields, to better express the intent behind these checks, and the rules they are inspecting, rather than just simply comparing strings.