### PR TITLE
minor fixes in some auditd checks for MAC-policy and enabled mode

### DIFF
--- a/controls/ubuntu-18.04-server-cis-4.1.17.rb
+++ b/controls/ubuntu-18.04-server-cis-4.1.17.rb
@@ -36,7 +36,8 @@ line
   tag cis_cdc_version: "7"
   tag cis_rid: "4.1.17"
 
-  describe auditd do
-    its('lines') { should include "-e 2" }
+  last_line = command("grep \"^\\s*[^#]\" /etc/audit/audit.rules | tail -1")
+  describe last_line do
+    its('stdout.strip') { should cmp "-e 2" }
   end
 end

--- a/controls/ubuntu-18.04-server-cis-4.1.6.rb
+++ b/controls/ubuntu-18.04-server-cis-4.1.6.rb
@@ -56,10 +56,9 @@ security contexts, leading to a compromise of the system."
   tag cis_cdc_version: "7"
   tag cis_rid: "4.1.6"
 
-
   files = [
-    '/etc/apparmor/',
-    '/etc/apparmor.d/'
+    '/etc/apparmor', # note no trailing `/` on directories
+    '/etc/apparmor.d'
   ]
 
   files.each do |file|


### PR DESCRIPTION
A couple more mistakes I found:

* the `auditd` resource, being based on the output of `auditctl -l`, doesn't work for checking control rules like `-e`. As far as I can tell, the only way to check this is to inspect the contents of `/etc/audit/audit.rules` and hope that these rules are the ones that are loaded. (This is how the 'check' is constructed in the CIS benchmark.)
* file auditing on directories should not include the trailing slash, it seems. This is contrary to the official 'check' in the benchmark, which does include grepping the output of `auditctl -l` for the trailing slash. I guess this is just a mistake in the benchmark.